### PR TITLE
Fix constellation fade distance

### DIFF
--- a/src/celengine/render.cpp
+++ b/src/celengine/render.cpp
@@ -1609,7 +1609,7 @@ void Renderer::render(const Observer& observer,
 
     Matrices asterismMVP = { &projection, &modelView };
 
-    float dist = observerPosLY.norm() * 1.6e4f;
+    float dist = observerPosLY.norm();
     renderAsterisms(universe, dist, asterismMVP);
     renderBoundaries(universe, dist, asterismMVP);
 


### PR DESCRIPTION
As per Issue #2176. Removed the random scaling factor applied to “dist” value, which is confusing and unintuitive. Now constellation lines should show up at interstellar distances, as preferred by many users. If fading at smaller distance is preferred then it would make sense to change the constants themselves rather than this.